### PR TITLE
Update rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@
 - Minor: Allow unused args prefixed with underscore
 - Minor: Fix `@typescript-eslint/no-shadow`
 - Minor: Fix `@typescript-eslint/no-non-null-assertion`
+- Minor: Disable `security/detect-non-literal-fs-filename`
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## HEAD (Unreleased)
 
-* Major: Enable `@typescript-eslint/naming-convention`
-* Minor: Allow unused args prefixed with underscore
-* Minor: Fix `@typescript-eslint/no-shadow`
-* Minor: Fix `@typescript-eslint/no-non-null-assertion`
+- Major: Enable `@typescript-eslint/naming-convention`
+- Minor: Allow unused args prefixed with underscore
+- Minor: Fix `@typescript-eslint/no-shadow`
+- Minor: Fix `@typescript-eslint/no-non-null-assertion`
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
-_(none)_
+* Major: Enable `@typescript-eslint/naming-convention`
+* Minor: Allow unused args prefixed with underscore
+* Minor: Fix `@typescript-eslint/no-shadow`
+* Minor: Fix `@typescript-eslint/no-non-null-assertion`
 
 ---

--- a/es6/__fixtures__/ok.js
+++ b/es6/__fixtures__/ok.js
@@ -33,3 +33,7 @@ Object.keys(files).forEach(name => {
     t.deepEquals(reactRuleIds, [], 'there are no react/ rules');
   });
 });
+
+export const x = (_unused) => {
+  return 4;
+};

--- a/es6/__fixtures__/ok.js
+++ b/es6/__fixtures__/ok.js
@@ -34,6 +34,10 @@ Object.keys(files).forEach(name => {
   });
 });
 
+// 'no-underscore-dangle': 'off'
+const _underscore = 123;
+
 export const x = (_unused) => {
-  return 4;
+  return _underscore;
 };
+

--- a/es6/rules.js
+++ b/es6/rules.js
@@ -3,14 +3,15 @@ module.exports = {
     // Allowing groups
     'sort-imports': ['off', { allowSeparatedGroups: true }],
 
-    // false positive prone, https://github.com/nodesecurity/eslint-plugin-security/issues/21
-    'security/detect-object-injection': 'off',
-
     // Allow unused args with underscore
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
     // conflicts with prettier
     'array-bracket-spacing': 'off',
-    'max-len': 'off'
+    'max-len': 'off',
+
+    // overly strict security rules
+    'security/detect-object-injection': 'off', // false positive prone, https://github.com/nodesecurity/eslint-plugin-security/issues/21
+    'security/detect-non-literal-fs-filename': 'off' // many false positives
   }
 };

--- a/es6/rules.js
+++ b/es6/rules.js
@@ -6,6 +6,9 @@ module.exports = {
     // false positive prone, https://github.com/nodesecurity/eslint-plugin-security/issues/21
     'security/detect-object-injection': 'off',
 
+    // Allow unused args with underscore
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
     // conflicts with prettier
     'array-bracket-spacing': 'off',
     'max-len': 'off'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": ["node_modules", "**/__fixtures__/*"]
 }

--- a/typescript/__fixtures__/ok.ts
+++ b/typescript/__fixtures__/ok.ts
@@ -36,9 +36,12 @@ Object.keys(files).forEach(name => {
   });
 });
 
+// 'no-underscore-dangle': 'off'
+const _underscore = 123;
+
 // @typescript-eslint/no-unused-vars: ['error', { argsIgnorePattern: '^_' }]
 export const x = (_unused: string): number => {
-  return 4;
+  return _underscore;
 };
 
 // '@typescript-eslint/naming-convention': [

--- a/typescript/__fixtures__/ok.ts
+++ b/typescript/__fixtures__/ok.ts
@@ -35,3 +35,22 @@ Object.keys(files).forEach(name => {
     t.deepEquals(reactRuleIds, [], 'there are no react/ rules');
   });
 });
+
+// @typescript-eslint/no-unused-vars: ['error', { argsIgnorePattern: '^_' }]
+export const x = (_unused: string): number => {
+  return 4;
+};
+
+// '@typescript-eslint/naming-convention': [
+//   'error',
+//   { selector: 'enumMember', format: null }
+// ]
+export enum X {
+  camelCase,
+  PascalCase,
+  snake_case,
+  UPPER_CASE
+}
+
+// non-null assertions: false
+export const includesBaz: boolean = foo.bar!.includes('baz');

--- a/typescript/rules.js
+++ b/typescript/rules.js
@@ -4,6 +4,15 @@ module.exports = {
     'no-extra-parens': 'off',
     '@typescript-eslint/no-extra-parens': ['error'],
 
+    // Replace 'no-unused-vars' rule with '@typescript-eslint' version
+    'no-unused-vars': 'off',
+    // Allow unused args with underscore
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
+    // Replace 'no-shadow' rule with '@typescript-eslint' version
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
+
     // Warning only
     '@typescript-eslint/no-explicit-any': ['warn', { ignoreRestArgs: true }],
 
@@ -15,6 +24,9 @@ module.exports = {
      * - when dealing with APIs that return Data | undefined but in some cases, we know for sure the data is available. eg: new Map(['foo', 'bar']).get('foo')!
      * - Angular's Input sometimes won't have default value, these will be subjected to ESLint's no-initializer rule. "?:" adds "undefined" to the type but "!:" won't
      */
-    'no-non-null-assertion': 'off'
+    '@typescript-eslint/no-non-null-assertion': 'off',
+
+    // Allow loose naming convention for enum members
+    '@typescript-eslint/naming-convention': ['error', { selector: 'enumMember', format: null }]
   }
 };

--- a/typescript/rules.js
+++ b/typescript/rules.js
@@ -27,6 +27,10 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
 
     // Allow loose naming convention for enum members
-    '@typescript-eslint/naming-convention': ['error', { selector: 'enumMember', format: null }]
+    '@typescript-eslint/naming-convention': ['error', { selector: 'enumMember', format: null }],
+
+    // overly strict security rules
+    'security/detect-object-injection': 'off', // false positive prone, https://github.com/nodesecurity/eslint-plugin-security/issues/21
+    'security/detect-non-literal-fs-filename': 'off' // many false positives
   }
 };


### PR DESCRIPTION
## Summary

* Major: Enable `@typescript-eslint/naming-convention`
* Minor: Allow unused args prefixed with underscore
* Minor: Fix `@typescript-eslint/no-shadow`
* Minor: Fix `@typescript-eslint/no-non-null-assertion`
* Minor: Disable `security/detect-non-literal-fs-filename`

## Changes are... (See Versioning Policy)

- [x] Major (more linting errors)
- [ ] Minor (same or less linting errors)
- [ ] Patch (non-user-facing changes)

## Checklist

- [x] \*Added unit tests
- [x] \*Added a code reviewer
- [x] Added changes to `CHANGELOG.md` under HEAD (Unreleased)

_\*required_
